### PR TITLE
Refactor Context class to support immutability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     koto (0.1.0)
       parser (~> 3.0)
+      spaghetti_stack (~> 0.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -17,6 +18,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     rake (13.0.3)
+    spaghetti_stack (0.2.1)
 
 PLATFORMS
   x86_64-linux

--- a/bin/console
+++ b/bin/console
@@ -6,35 +6,37 @@ require "koto"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
-  def parser
-    builder = Koto::Parser::Builders::Default.new
-    ::Parser::CurrentRuby.new(builder)
-  end
+CODE = "module AST; class Context; private; def get_in(node); stack << node; end; end; end".freeze
 
-  def parse(source)
-    buffer = ::Parser::Source::Buffer.new('(string)', :source => source)
-    parser.parse(buffer)
-  end
+def parser
+  builder = Koto::Parser::Builders::Default.new
+  ::Parser::CurrentRuby.new(builder)
+end
 
-  def n(type, children)
-    Koto::Parser::AST::Node.new(type, children)
-  end
+def parse(source)
+  buffer = ::Parser::Source::Buffer.new('(string)', :source => source)
+  parser.parse(buffer)
+end
 
-  def processor
-    Koto::Parser::AST::Processor.new
-  end
+def n(type, children)
+  Koto::Parser::AST::Node.new(type, children)
+end
 
-  def process(node)
-    processor.process(node)
-  end
+def processor
+  Koto::Parser::AST::Processor.new
+end
 
-  def context
-    Koto::Parser::AST::Processor::Context.new
-  end
+def process(node)
+  processor.process(node)
+end
 
-  def name_processor
-    Koto::Parser::AST::Processor::NameProcessor.new
-  end
+def context
+  Koto::Parser::AST::Processor::Context.new
+end
+
+def name_processor
+  Koto::Parser::AST::Processor::NameProcessor.new
+end
 
 # (If you use this, don't forget to add pry to your Gemfile!)
 require "pry"

--- a/koto.gemspec
+++ b/koto.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'parser', '~> 3.0'
+  spec.add_dependency 'spaghetti_stack', '~> 0.2.1'
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/koto/parser/ast/node.rb
+++ b/lib/koto/parser/ast/node.rb
@@ -6,17 +6,14 @@ module Koto
       class Node < ::Parser::AST::Node
         attr_reader :name
         attr_reader :context
+        attr_reader :symbols
 
-        def scope
+        def current_scope
           context.current_scope
         end
 
         def access
           context.access
-        end
-
-        def symbols
-          context.symbols
         end
 
         def assign_properties(properties)
@@ -29,6 +26,11 @@ module Koto
           if (context = properties[:context])
             context = context.deep_dup if context.frozen?
             @context = context
+          end
+
+          if (symbols = properties[:symbols])
+            symbols = symbols.dup if symbols.frozen?
+            @symbols = symbols
           end
         end
       end

--- a/lib/koto/parser/ast/processor/context.rb
+++ b/lib/koto/parser/ast/processor/context.rb
@@ -6,33 +6,89 @@ module Koto
       class Processor
 
         class Context
+          attr_reader :scopes
           attr_reader :stack
           attr_reader :access
 
           def initialize
-            @stack  = []
-            @access = :public
+            @scopes  = SpaghettiStack.new(SymbolTable.new)
+            @stack   = []
+            @access  = :public
+
+            freeze
           end
 
           def get_in(node)
-            stack << node
+            copy = self.deep_dup
+            copy.get_in!(node)
           end
 
-          def get_out(node)
-            stack.pop
+          def get_in!(node)
+            @scopes << SymbolTable.new
+            @stack << node
+
+            self
+          end
+
+          protected :get_in!
+
+          def get_out
+            copy = self.deep_dup
+            copy.get_out!
+          end
+
+          def get_out!
+            symbol_table = symbols.freeze
+            active_scope.update(symbol_table)
+
+            unless top_level?
+              @scopes.pop
+              @stack.pop
+            end
+
+            return symbol_table, self
+          end
+
+          protected :get_out!
+
+          def save(node)
+            copy = self.deep_dup
+            copy.save! node
+          end
+
+          def save!(node)
+            symbol_table = symbols.record(node)
+            active_scope.update(symbol_table)
+
+            self
+          end
+
+          protected :save!
+
+          def symbols
+            active_scope.data
+          end
+
+          def active_scope
+            @scopes.top
           end
 
           def current_scope
-            stack.last
+            @stack.last
           end
 
           def switch_access_to(access)
-            return unless [:public, :private, :protected].include? access
-            @access = access if access != @access
+            return self unless ACCESS_METHODS.include?(access) &&
+              access != @access
+
+            copy = self.dup
+            copy.instance_variable_set(:@access, access)
+
+            copy
           end
 
           def top_level?
-            stack.empty?
+            @stack.empty?
           end
 
           def in_class?
@@ -67,6 +123,17 @@ module Koto
 
           def in_dynamic_block?
             in_block? || in_lambda?
+          end
+
+          def deep_dup
+            copy = self.dup
+
+            copy.instance_variables.each do |attr|
+              value = instance_variable_get(attr).dup
+              copy.instance_variable_set attr, value
+            end
+
+            copy
           end
         end
       end

--- a/lib/koto/parser/ast/processor/context/symbol_table.rb
+++ b/lib/koto/parser/ast/processor/context/symbol_table.rb
@@ -12,6 +12,7 @@ module Koto
 
           def record(symbol)
             self[symbol.name] = symbol
+            self
           end
 
           def variables

--- a/test/koto_test.rb
+++ b/test/koto_test.rb
@@ -27,10 +27,17 @@ class KotoTest < Minitest::Test
     assert_equal unscoped_constant, processor.process(scoped_constant)
 
     p = processor
-    c = p.context
 
-    node = parse "class Context; private; def method; end; end"
-    node = p.process node
-    assert_equal :private, c.access
+    ast = parse "class Context; private; def push; end; end"
+    p.process(ast)
+
+    c       = p.context
+    symbols = c.symbols
+
+    klass  = symbols[:Context]
+    method = klass.symbols[:push]
+
+    assert_equal :public, klass.access
+    assert_equal :private, method.access
   end
 end

--- a/test/parser/ast/processor/context_test.rb
+++ b/test/parser/ast/processor/context_test.rb
@@ -5,20 +5,41 @@ require "test_helper"
 class ContextTest < Minitest::Test
   include TestHelper
 
-  def test_current_scope
+  def test_should_save_nodes
+    p = processor
+
+    node = parse "module AST; end"
+    node = p.process(node)
+
+    c = p.context
+
+    assert c.symbols[:AST]
+  end
+
+  def test_parent_scope
     c = context
     assert c.top_level?
 
     mod = parse "module AST; end"
-    c.get_in(mod)
-    assert c.in_module?
+    a = c.get_in(mod)
+    assert a.in_module?
+    assert c.top_level?
 
     klass = parse "class Context; end"
-    c.get_in(klass)
-    assert c.in_class?
+    b = a.get_in(klass)
+    assert b.in_class?
+    assert c.top_level?
 
     method = parse "def get_in(node); end"
-    c.get_in(method)
-    assert c.in_def?
+    d = b.get_in(method)
+    assert d.in_def?
+    assert c.top_level?
+  end
+
+  def test_access
+    c = context
+    a = c.switch_access_to :private
+    assert_equal :private, a.access
+    assert_equal :public, c.access
   end
 end

--- a/test/parser/ast/processor_test.rb
+++ b/test/parser/ast/processor_test.rb
@@ -6,7 +6,7 @@ class ProcessorTest < MiniTest::Test
   include TestHelper
 
   def test_should_convert_scoped_constants_to_unscoped_constants
-    scoped_constant   = parse("Scoped::Constant")
+    scoped_constant   = parse "Scoped::Constant"
     unscoped_constant = n(:const, [nil, :"Scoped::Constant"])
     assert_equal unscoped_constant, process(scoped_constant)
   end
@@ -23,11 +23,12 @@ class ProcessorTest < MiniTest::Test
     assert c
 
     node = parse "module AST; class Context; def get_in(node); stack << node; end; end; end"
-    node = p.process node
-    assert_equal :module, node.type
+    node = p.process(node)
+    assert c.symbols[:AST].context.top_level?
 
-    node = parse "class Context; private; def method; end; end"
-    node = p.process node
+    node = parse "private; def method; end;"
+    node = p.process(node)
+    c = p.context
     assert_equal :private, c.access
   end
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -6,7 +6,7 @@ class ParserTest < Minitest::Test
   include TestHelper
 
   def test_should_return_a_custom_node
-    node = parse("class Node; end")
+    node = parse "class Node; end"
     assert node.is_a? Koto::Parser::AST::Node
   end
 end


### PR DESCRIPTION
Any operation that changes the state creates a new `Context`.
```ruby
code = "class Context; private; def get_in(node); end; end"
node = Parser::CurrentRuby.parse(code)

context.get_in(node) 
# => returns a new Context
context.switch_access_to :private
# => new Context
context.get_out
# => new Context
context.save(node) 
# => new Context
```