### PR TITLE
Some refactoring to better handle frozen states

### DIFF
--- a/lib/koto.rb
+++ b/lib/koto.rb
@@ -4,6 +4,7 @@ require 'parser/current'
 
 module Koto
   require "koto/version"
+  require "koto/core_ext/object"
 
   module Parser
 

--- a/lib/koto/core_ext/object.rb
+++ b/lib/koto/core_ext/object.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Object
+  def deep_dup
+    copy = self.dup
+
+    copy.instance_variables.each do |attr|
+      value = instance_variable_get(attr).dup
+      copy.instance_variable_set attr, value
+    end
+
+    copy
+  end
+end

--- a/lib/koto/parser/ast/node.rb
+++ b/lib/koto/parser/ast/node.rb
@@ -24,12 +24,10 @@ module Koto
           end
 
           if (context = properties[:context])
-            context = context.deep_dup if context.frozen?
             @context = context
           end
 
           if (symbols = properties[:symbols])
-            symbols = symbols.dup if symbols.frozen?
             @symbols = symbols
           end
         end

--- a/lib/koto/parser/ast/processor/context.rb
+++ b/lib/koto/parser/ast/processor/context.rb
@@ -20,21 +20,21 @@ module Koto
 
           def get_in(node)
             copy = self.deep_dup
-            copy.get_in!(node)
+            copy.send :get_in!, node
           end
 
           def get_in!(node)
             @scopes << SymbolTable.new
             @stack << node
 
-            self
+            self.freeze
           end
 
-          protected :get_in!
+          private :get_in!
 
           def get_out
             copy = self.deep_dup
-            copy.get_out!
+            copy.send :get_out!
           end
 
           def get_out!
@@ -46,24 +46,24 @@ module Koto
               @stack.pop
             end
 
-            return symbol_table, self
+            return symbol_table, self.freeze
           end
 
-          protected :get_out!
+          private :get_out!
 
           def save(node)
             copy = self.deep_dup
-            copy.save! node
+            copy.send :save!, node
           end
 
           def save!(node)
             symbol_table = symbols.record(node)
             active_scope.update(symbol_table)
 
-            self
+            self.freeze
           end
 
-          protected :save!
+          private :save!
 
           def symbols
             active_scope.data
@@ -84,7 +84,7 @@ module Koto
             copy = self.dup
             copy.instance_variable_set(:@access, access)
 
-            copy
+            copy.freeze
           end
 
           def top_level?
@@ -123,17 +123,6 @@ module Koto
 
           def in_dynamic_block?
             in_block? || in_lambda?
-          end
-
-          def deep_dup
-            copy = self.dup
-
-            copy.instance_variables.each do |attr|
-              value = instance_variable_get(attr).dup
-              copy.instance_variable_set attr, value
-            end
-
-            copy
           end
         end
       end


### PR DESCRIPTION
Changes :
- Any operation in `Context` which changes the state will return a new frozen `Context`.
- `Context#get_in!`, `Context#get_out!` and `Context#save!` are now private methods.
- `#deep_dup` is now defined on the `Object` class.
-  `Node#assign_properties` now stores frozen objects.